### PR TITLE
Stop shotcodes from appearing in og:description

### DIFF
--- a/code/Extensions/OpenGraphObjectExtension.php
+++ b/code/Extensions/OpenGraphObjectExtension.php
@@ -131,7 +131,7 @@ class OpenGraphObjectExtension extends SiteTreeExtension implements IOGObjectExp
 		// Intelligent fallback for SiteTree instances
 		$contentField = $this->owner->dbObject('Content');
 		if ($contentField instanceof Text) {
-			return $contentField->FirstParagraph();
+			return $contentField->Summary(100);
 		}
 	}
 


### PR DESCRIPTION
Shortcodes for links were showing in og:description. This patch ensures that the shortcodes are removed.