### PR TITLE
bug fix 

### DIFF
--- a/src/Extensions/OpenGraphObjectExtension.php
+++ b/src/Extensions/OpenGraphObjectExtension.php
@@ -195,9 +195,11 @@ class OpenGraphObjectExtension extends DataExtension implements IOGObjectExplici
     {
         // Check MetaDescription has given content
         if ($this->owner->hasField('MetaDescription')) {
-            $description = trim($this->owner->MetaDescription);
-            if (!empty($description)) {
-                return $description;
+            if($this->owner->MetaDescription != null || $this->owner->MetaDescription != ''){
+                $description = trim($this->owner->MetaDescription);
+                if (!empty($description)) {
+                    return $description;
+                }
             }
         }
 


### PR DESCRIPTION
[Deprecated] trim(): Passing null to parameter #1 ($string) of type string is deprecated
vendor/tractorcow/silverstripe-opengraph/src/Extensions/OpenGraphObjectExtension.php