### PR TITLE
FIX: Don't force recipe usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,13 @@
         "issues": "http://github.com/tractorcow/silverstripe-opengraph/issues"
     },
     "require": {
-        "silverstripe/recipe-core": "^1 || ^4 || ^5"
+        "silverstripe/framework": "^4 || ^5",
+        "silverstripe/siteconfig": "^4 || ^5"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3",
-        "silverstripe/recipe-cms": "^1 || ^4 || ^5"
+        "silverstripe/assets": "^1 || ^2",
+        "silverstripe/cms": "^4 || ^5",
+        "silverstripe/recipe-testing": "^3"
     },
     "extra": {
         "installer-name": "opengraph",


### PR DESCRIPTION
We don’t use the recipes directly, so when this module gets installed (and the recipe along with it) a bunch of recipe files like `mysite.yml` get created alongside it.

I’ve only included framework and siteconfig in the base requirements: as far as I can tell these are the only two _required_ for this module to run. CMS/assets modules are referenced in places, but as things like `instanceof ` checks, so shouldn’t be  directly necessary outside of tests.